### PR TITLE
Corrección de erratas, tildes y errores de dedos en el cap. 1

### DIFF
--- a/01_values.txt
+++ b/01_values.txt
@@ -18,7 +18,7 @@ ____
 (((Yuan-Ma)))(((Libro de la Programación)))(((datos
 binarios)))(((datos)))(((bit)))(((memoria))) En el mundo de las
 computadoras sólo existen los datos. Puedes leer, modificar y crear
-nuevos datos, pero culaquier cosa que no sea datos simplemente no 
+nuevos datos, pero culaquier cosa que no sea datos simplemente no
 existe. Todos estos datos son guardados en largas secuencias de bits
 y por lo tanto son parecidos.
 
@@ -68,15 +68,15 @@ y valores indefinidos.
 su nombre. Esto es conveniente. No tienes que reuinir el material de
 construcción de tus valores o pagar por ellos. Sólo llamas uno y _woosh_,
 lo tienes. No son creados de la nada, por supuesto. Cada valor tiene que
-estar almacenado en algún lugar, y si quieres usar una cantidad enorme 
+estar almacenado en algún lugar, y si quieres usar una cantidad enorme
 de estos al mismo tiempo, te podrías quedar sin bits. Afortunadamente,
-esto se convierte en un problema sólamente si los necesitas todos al 
+esto se convierte en un problema sólamente si los necesitas todos al
 mismo tiempo. Tan pronto como dejes de usar un valor se disipará, dejando
 sus bits para que sean reciclados como material de construcción de la
 próxima generación de valores.
 
-Este capítulo introduce los elementos atómicos de los programas en 
-JavaScript, los tipos de valores simples y los operadores que pueden 
+Este capítulo introduce los elementos atómicos de los programas en
+JavaScript, los tipos de valores simples y los operadores que pueden
 actuar sobre tales valores.
 
 == Números ==
@@ -95,16 +95,16 @@ bits para el número 13 exista dentro de la memoria de la computadora.
 
 (((número,representación)))(((bit)))JavaScript usa una cantidad fija
 de bits, 64, para guardar un valor del tipo número. Existe un límite
-en la cantidad de patrones que se pueden hacer con 64 bits, lo que 
+en la cantidad de patrones que se pueden hacer con 64 bits, lo que
 significa que la cantidad de números que puedes representar también es
 limitada. Para _N_ ((dígito))s decimales, la cantidad de números que
 pueden ser representados es 10^_N_^. Similarmente, dados 64 dígitos
 binarios, puedes representar 2^64^ números diferentes, que es cerca de
 18 cuatrillones (un 18 con 18 ceros después). Eso es mucho.
 
-La memoria de la computadora solía ser mucho más pequeña, y la gente 
+La memoria de la computadora solía ser mucho más pequeña, y la gente
 tendía a usar grupos de 8 ó 16 bits para representar sus números. Era
-fácil _((desbordar))_ accidentalmente números tan pequeños: terminar 
+fácil _((desbordar))_ accidentalmente números tan pequeños: terminar
 con un número que no pudiera ser almacenado en el número dado de bits. Hoy,
 incluso las computadoras personales tienen mucha memoria, así
 que eres libre de usar grupos de 64 bits, lo que significa que
@@ -114,7 +114,7 @@ tratando con números verdaderamente astronómicos.
 (((signo)))(((número de punto flotante)))(((número fraccionario)))(((bit de signo)))No
 todos los número enteros debajo de 18 cuatrillones caben en un número
 de JavaScript. Esos bits también guardan números negativos, así
-que un bit indica el signo del número. Un problema mayor es que 
+que un bit indica el signo del número. Un problema mayor es que
 los números no enteros también deben ser representados. Para hacer esto,
 algunos de los bits son usados para guardar la posición del punto decimal.
 El número entero máximo real que puede ser guardado está más cerca del rango de
@@ -139,7 +139,7 @@ del número:
 
 Esto es 2.998 × 10^8^ = 299,800,000.
 
-(((pi)))(((número, precisión de)))(((número de punto flotante)))Calculos con 
+(((pi)))(((número, precisión de)))(((número de punto flotante)))Cálculos con
 números enteros (en inglés llamados _((integer))_) más pequeños que el supracitado
 9 trillones, están garantizados para siempre ser precisos. Desafortunadamente,
 cálculos con números fraccionarios generalmente no lo son. Justo como π (pi)
@@ -156,7 +156,7 @@ y no como valores precisos.
 binario)))(((aritmética)))(((adición)))(((multiplicación)))Lo principal que
 se hace con los números es la aritmética. Las operaciones aritméticas
 como la suma o la multiplicación toman dos valores y producen uno
-nuevo a partir de estos. Así es como lucen e JavaScript:
+nuevo a partir de estos. Así es como lucen en JavaScript:
 
 [source,javascript]
 ----
@@ -166,11 +166,11 @@ nuevo a partir de estos. Así es como lucen e JavaScript:
 (((operador,applicación)))(((asterisco)))(((símbolo
 más)))(((operador pass:[*])))(((operador +))) Los símbolos `+` y `*`
 son llamados _operadores_. El primero representa la suma y el segundo
-la multiplicación. Al poner un operador entre dos valores, se 
+la multiplicación. Al poner un operador entre dos valores, se
 aplicará la operación a esos valores y producirá un nuevo valor.
 
 (((agrupamiento)))(((paréntesis)))(((precedencia)))¿Significa el ejemplo
-anterior: "suma 4 y 100, y multitplica el resultado por 11", o es la
+anterior: "suma 4 y 100, y multiplica el resultado por 11", o es la
 multiplicación ralizada antes de hacer la suma? Como pudiste haber adivinado,
 la multiplicación ocurre primero. Pero como en matemáticas, puedes cambiar
 esto mediante encerrar en paréntesis la suma.
@@ -185,23 +185,23 @@ esto mediante encerrar en paréntesis la suma.
 -)))(((operador /)))Para la resta existe el operador `-`,
 y la división se puede hacer con el operador `/`.
 
-Cuando los operadores aparecen juntos sin paréntesis, el order en el que
+Cuando los operadores aparecen juntos sin paréntesis, el orden en el que
 son aplicados es determinado por su _((precedencia))_. El ejemplo muestra
-que la multiplicación se aplica antes que la suma. El operador `/` tiene 
+que la multiplicación se aplica antes que la suma. El operador `/` tiene
 la misma precedencia que `*`. De igual forma pasa con `+` y `-`. Cuando
 varios operadores con la misma precedencia aparecen juntos, como en
-`1 - 2 + 1`, son aplicados de izquierda a derecha: `(1 - 2) + 1`. 
+`1 - 2 + 1`, son aplicados de izquierda a derecha: `(1 - 2) + 1`.
 
 Estas reglas de precedencia son algo de lo que no te deberías
 de preocupar. Cuando tengas duda, simplemente agrega paréntesis.
 
 (((operador módulo)))(((división)))(((operador sobrante)))(((operador
 %)))Existe un operador aritmético más, que podrías no reconocer
-inmediatamente. El símbolo `%` es usado para representar la 
-operación _sobrante_. `X % Y` es el sobrante de dividir `X` entre 
+inmediatamente. El símbolo `%` es usado para representar la
+operación _sobrante_. `X % Y` es el sobrante de dividir `X` entre
 `Y`. Por ejemplo, `314 % 100` produce `14`, y `144 % 12` da `0`.
 La precedencia del sobrante es la misma que la de la multiplicación
-y división. Verás a menudo este operador referido como _módulo_, 
+y división. Verás a menudo este operador referido como _módulo_,
 aunque técnicamente _sobrante_ es más preciso.
 
 === Números Especiales ===
@@ -225,9 +225,9 @@ preciso, significativo.
 
 == Cadenas ==
 
-(((sintaxis)))(((texto)))(((caracter)))(((cadena,notación)))(((caracter
-comilla simple)))(((caracter comilla doble)))(((comillas)))El siguiente
-tipo de data básico son las _cadenas_. Estas son usadas para representar
+(((sintaxis)))(((texto)))(((carácter)))(((cadena,notación)))(((carácter
+comilla simple)))(((carácter comilla doble)))(((comillas)))El siguiente
+tipo de dato básico son las _cadenas_. Estas son usadas para representar
 texto. Son declaradas al poner el contenido entre comillas.
 
 [source,javascript]
@@ -241,20 +241,20 @@ cadenas de texto mientras coincidan al principio y al final.
 
 (((salto de línea)))(((caracter de nueva línea)))(((newline)))Casi cualquier
 cosa puede estar entre comillas, y JavaScript creará una cadena. Pero unos
-cuantos caracteres son un poco difíceles. Puedes imaginar que poner
-comillas dentro de comillas puede ser difícil. _Newlines_ (el caracter
+cuantos caracteres son un poco difíciles. Puedes imaginar que poner
+comillas dentro de comillas puede ser difícil. _Newlines_ (el carácter
 salto de línea, lo que obtines cuando presionas Enter), tampoco puede
 ser introducido entre comillas. La cadena tiene que permanecer en una
 sola línea.
 
 (((escape,en cadenas)))(((diagonal invertida)))Para hacer posible
-la inclusión de estos caracteres en  una cadena de texto, la siguiente
+la inclusión de estos caracteres en una cadena de texto, la siguiente
 notación es usada: cuando una diagonal invertida(_backslash_: `\`)
-se encuentra dentro de un texto entre comillas, indica que el caracter
+se encuentra dentro de un texto entre comillas, indica que el carácter
 siguiente tiene un significado especial. Esto es llamado _escapar_ el
-caracter. Una comilla que es precedida por una diagonal invertida
+carácter. Una comilla que es precedida por una diagonal invertida
 no terminará la cadena, sino que será parte de ella. Cuando un
-caracter `n` sigue a una diagonal invertida, se interpreta como
+carácter `n` sigue a una diagonal invertida, se interpreta como
 una nueva línea. Similarmente, un `t` después de la diagonal invertida
 significa un ((tabulador)). Tomemos la siguiente cadena:
 
@@ -272,19 +272,19 @@ Y esta la segunda
 ----
 
 Existen, por supuesto, situaciones en las que querrás que una
-diagonal invertida sea sólo eso en una cadena de texto, no un 
+diagonal invertida sea sólo eso en una cadena de texto, no un
 código especial. Si dos diagonales invertidas están juntas, se volverán
 una, y sólo eso quedará como resultado en el valor de la cadena.
-Así es como la cadena "++Un caracter de nueva línea es escrito "\n".++"
+Así es como la cadena "++Un carácter de nueva línea es escrito "\n".++"
 puede ser expresada:
 
 [source,javascript]
 ----
-"Un caracter de nueva línea es escrito \"\\n\"."
+"Un carácter de nueva línea es escrito \"\\n\"."
 ----
 
 (((operador +)))(((concatenación)))Las cadenas de texto no pueden ser
-divididas numéricamente, multiplicadas, o restadas, pero el caracter
+divididas numéricamente, multiplicadas, o restadas, pero el carácter
 `+` _puede_ ser usado en ellas. No suma, sino que _concatena_; pega dos
 cadenas. La siguiente línea produce la cadena `"concatenar"`:
 
@@ -296,7 +296,7 @@ cadenas. La siguiente línea produce la cadena `"concatenar"`:
 Hay más maneras de manipular las cadenas, de las que hablaremos cuando
 lleguemos a los métodos en el link:04_data.html#methods[Capítulo 4].
 
-== Operadores Unarios ==
+== Operadores Unitario ==
 
 (((operador)))(((operador typeof)))(((tipo)))No todos los operadores
 son símbolos. Algunos son escritos como palabras. Un ejemplo es el
@@ -316,15 +316,15 @@ console.log(typeof "x")
 (((console.log)))(((salida)))(((consola de JavaScript)))Usaremos
 `console.log` para indicar que queremos ver el resultado de la evaluación
 de algo. Cuando corres ese código, el valor producido debería mostrarse en
-pantalla, aunque la forma en que aparece dependerá del en entorno en que
+pantalla, aunque la forma en que aparece dependerá del entorno en que
 estés corriendo el programa.
 
 (((negación)))(((operador -)))(((operador binario)))(((operador
 binario))) Los otros operadores que hemos visto operaban sobre
 dos valores, pero `typeof` sólamente toma uno. Los operadores que usan
-dos valores son llamados operadores _binarios_, mientras que aquellos 
-que sólo toman uno son llamados operadores _unarios_. El operador menos
-puede usar tanto como operador binario como operador unario.
+dos valores son llamados operadores _binarios_, mientras que aquellos
+que sólo toman uno son llamados operadores _unitarios_. El operador menos
+puede usar tanto como operador binario como operador unitario.
 
 [source,javascript]
 ----
@@ -338,7 +338,7 @@ console.log(- (10 - 2))
 necesitarás un valor que simplemente distinga entre dos posibilidades,
 como "sí" y "no" o "encendido" y "apagado". Para esto, JavaScript
 tiene un tipo _Booleano_, que tiene sólo dos valores, verdadero (true)
-y falso (false), que son simplemente estas palabras en inglés. 
+y falso (false), que son simplemente estas palabras en inglés.
 
 === Comparaciones ===
 
@@ -370,16 +370,16 @@ console.log("Aardvark" < "Zoroaster")
 es más o menos alfabética: las letras mayúsculas son siempre "menores"
 que las minúsculas, así que `"Z" < "a"` es verdad, y los caracteres no
 alfabéticos (!, -, y así por el estilo) son también incluidos en el
-ordenamiento. La comparación real está basada en el estéandar
+ordenamiento. La comparación real está basada en el estándar
 _((Unicode))_. Este estándar asigna un número a virtualemente cada
-caracter que alguna vez necesitarás, incluyendo caracteres del Griego,
-Árabe, Japonés, Tamil, y otros alfabetos. Tener tales números es 
+carácter que alguna vez necesitarás, incluyendo caracteres del griego,
+árabe, japonés, tamil, y otros alfabetos. Tener tales números es
 útil para guardar las cadenas de texto dentro de la computadora porque
 hace posible representarlas como una secuencia de números. Cuando
 comparamos cadenas, JavaScript va de izquierda a derecha, comparando
 los códigos numéricos de los caracteres uno por uno.
 
-(((igualdad)))(((operador >=)))(((pass:[<=] operador)))(((operador 
+(((igualdad)))(((operador >=)))(((pass:[<=] operador)))(((operador
 ==)))(((operador != ))) Otros operadores similares son `>=` (mayor o
 igual a), `<=` (menor o igual a), `==` (igual a), y `!=` (no es igual
 a).
@@ -436,7 +436,7 @@ console.log(false || false)
 ----
 
 (((negación)))(((operador !)))_Not_ (Negación) es escrito como un símbolo
-de admiración (`!`). Es un operador binario que voltea el valor que se 
+de admiración (`!`). Es un operador binario que voltea el valor que se
 le de; `!true` produce `false` y `!false` regresa `true`.
 
 (((precedencia)))Cuando mezclamos estos operadores Booleanos con
@@ -455,7 +455,7 @@ paréntesis como sea posible:
 
 (((ejecución condicional)))(((operador ternario)))(((operador ?:
 )))(((operador condicional)))(((caracter dos puntos)))(((signo de
-interrogación)))El último operador lógico del que hablaré no es unario,
+interrogación)))El último operador lógico del que hablaré no es unitario,
 ni binario, sino _ternario_, opera en tres valores. Este es escrito con
 un símbolo de interrogación  y dos puntos, como sigue:
 
@@ -467,10 +467,10 @@ console.log(false ? 1 : 2);
 // → 2
 ----
 
-Esste es llamado el operador _condicional_ (o algunas veces el operador
+Este es llamado el operador _condicional_ (o algunas veces el operador
 _tenario_ dado que es el único operador de este tipo en el lenguaje).
 El valor a la izquierda del signo de interrogación "escoge" cuál de los
-otros dos valores resultará. Cuando es verdadero, el valor central es 
+otros dos valores resultará. Cuando es verdadero, el valor central es
 escogido, y cuando es falso, el valor de la derecha se da como resultado.
 
 == Valores Indefinidos (Undefined) ==
@@ -481,7 +481,7 @@ de un valor con significado. Son valores en sí mismos, pero no poseen
 ninguna información.
 
 Muchas operaciones en el lenguaje que no producen un valor con significado
-(lo verás después) producen `undefined` simplemente porque tienen producir
+(lo verás después) producen `undefined` simplemente porque tienen que producir
 _algún_ valor.
 
 La diferencia en el significado entre `undefined` y `null` es un accidente del
@@ -515,8 +515,8 @@ JavaScript convertirá silenciosamente el valor en el tipo de dato
 que espera, usando un conjunto de reglas que a menudo no son lo que
 tú quieres o esperas. Esto es llamado _((coerción de tipo))_. Así que
 el `null` en la primera expresión se vuelve `0`, y el `"5"` en la
-segunda expresión se convierte en `5` (de cadena a número). Aún así, 
-em la tercera expresión, `+` intenta hacer concatenación de cadenas
+segunda expresión se convierte en `5` (de cadena a número). Aún así,
+en la tercera expresión, `+` intenta hacer concatenación de cadenas
 antes de suma numérica, así que el `1` es convertido en `"1"` (de
 número a cadena).
 
@@ -547,15 +547,15 @@ console.log(null == 0);
 ----
 
 Este último comportamiento es útil a menudo. Cuando quieres probar
-si un valor tiene un significado real en vez de `null` o `undefined`, 
+si un valor tiene un significado real en vez de `null` o `undefined`,
 simplemente comparas contra `null` con el operador `==` (o `!=`).
 
 (((coerción de tipos)))(((Boolean,conversión a)))(((operador
- ===)))(((operador !==)))(((comparación)))¿Y si quieres proobar
-si algo se refiere precisamente al valor `false`? Las reglas para 
+ ===)))(((operador !==)))(((comparación)))¿Y si quieres probar
+si algo se refiere precisamente al valor `false`? Las reglas para
 convertir cadenas y números a Booleanos dicen que `0`, `NaN` y la
-cadena vacía (`""`) cuantan como `false`, mientras que todos los
-demás valores cuentan como `true`. Debido a esto, expresiones como 
+cadena vacía (`""`) cuentan como `false`, mientras que todos los
+demás valores cuentan como `true`. Debido a esto, expresiones como
 `0 == false` y `"" == false` también son verdaderas. Para casos como
 este en el que _no_ quieres que ocurra ninguna conversión automática
 de tipos, existen dos operadores extra: `===` y `!==`. El primero
@@ -592,9 +592,9 @@ console.log("Karl" || "user")
 ----
 
 (((valor por defecto)))Esta funcionalidad permite al operador `||`
-ser usado como una manera de repaldarnos con un valor por defecto.
+ser usado como una manera de respaldarnos con un valor por defecto.
 Si le das en el lado izquierdo una expresión que puede producir
-un valor vacío, el valor de l aderecha será usado como reemplazo
+un valor vacío, el valor de la derecha será usado como reemplazo
 dado el caso.
 
 (((operador &&)))El operador `&&` funciona de manera similar, pero
@@ -612,7 +612,7 @@ _evaluación de corto circuito_ (short-circuit evaluation).
 
 (((operador ternario)))(((operador ?:)))(((operadores condicionales)))El
 operador condicional trabaja de una forma similar. La primera expresión
-es evaluada siempre, pero el segundo o tercer valor, el que no sea 
+es evaluada siempre, pero el segundo o tercer valor, el que no sea
 escogido, no se evalúa.
 
 == Resumen ==
@@ -623,14 +623,14 @@ cadenas, Booleanos, y valores indefinidos.
 Estos valores son creados al escribir su nombre (`true`, `null`) o
 valor (`13`, `"abc"`). Puedes combinar y transformar valores con los
 operadores. Vimos operadores binarios para aritmética(`+`, `-`,
-`*`, `/` y `%`), concatenación de cadenas (`+`), comparación 
+`*`, `/` y `%`), concatenación de cadenas (`+`), comparación
 (`==`, `!=`, `===`, `!==`, `<`, `>`, `<=`, `>=`), y lógica
-(`&&`, `||`), así como varios operadores unarios (`-` para hacer
+(`&&`, `||`), así como varios operadores unitarios (`-` para hacer
 negativo un número, `!` para negar lógicamente y `typeof` para
 obtener el tipo de un valor) y un operador ternario (`?:`) para
 elegir entre dos valores basándonos en un tercero.
 
 Esto te brinda suficiente información para usar JavaScript como una
-pequeña calculadora, pero no para mucho más. El 
+pequeña calculadora, pero no para mucho más. El
 link:02_program_structure.html#program_structure[siguiente capítulo]
 empezará a entremezclar estas expresiones en programas básicos.


### PR DESCRIPTION
Corrección de erratas, tildes y errores de dedos en el cap. 1
Cambiado "unario" (palabra inexistente en cantellano) por unitario.
Aplicada la norma 6.7 sobre uso de mayúsculas: no debe utilizarse mayúscula inicial en nombres de tribus, pueblos, lenguas y gentilicios.
